### PR TITLE
submodules: change url of libvfn to web url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "MacVFN/libvfn"]
 	path = MacVFN/libvfn
-	url = git@github.com:Baekalfen/libvfn.git
+	url = https://github.com/Baekalfen/libvfn
     branch = driverkit


### PR DESCRIPTION
Being able to clone and pull from the repository including the submodules without being logged in is useful when working with the tool in CI workflows on machines that are not logged into Github. When the submodule URL is the SSH key, this is not possible.